### PR TITLE
Баг фикс с CustomLocalizableValueService

### DIFF
--- a/Autolocalizable/Classes/Localization/CustomLocalizableValueService.swift
+++ b/Autolocalizable/Classes/Localization/CustomLocalizableValueService.swift
@@ -11,18 +11,22 @@ public final class CustomLocalizableValueService: LocalizableValueService {
 
     // MARK: - Private properties
 
-    private var dictionary: [Locale: String]
+    private var dictionary: [String: String]
+    private var defaultValue: String
 
     // MARK: - Initializing
 
-    public init(with dictionary: [Locale: String]) {
-        self.dictionary = dictionary
+    public init(with dictionary: [Locale: String], defaultValue: String) {
+        self.dictionary = dictionary.reduce(into: [String: String](), { (dict, oldItem) in
+            dict[oldItem.key.resourcesFileName] = oldItem.value
+        })
+        self.defaultValue = defaultValue
     }
 
     // MARK: - LocalizableValueService
 
     public func localized(_ table: String, _ key: String, _ args: [CVarArg], locale: Locale) -> String {
-        let format = dictionary[locale] ?? dictionary.first?.value ?? ""
+        let format = dictionary[locale.resourcesFileName] ?? defaultValue
         return String(format: format, locale: locale, arguments: args)
     }
 

--- a/Autolocalizable/Classes/Localization/LocalizableStringItem.swift
+++ b/Autolocalizable/Classes/Localization/LocalizableStringItem.swift
@@ -121,9 +121,14 @@ public struct LocalizableStringItem {
 /// CustomLocalizableValueService supporting
 public extension LocalizableStringItem {
 
-    init(args: [CVarArg] = [], localizationsDictionary: [Locale: String]) {
+    init(args: [CVarArg] = [], localizationsDictionary: [Locale: String], defaultValue: String) {
         self.init("", args)
-        self = set(localizableService: CustomLocalizableValueService(with: localizationsDictionary))
+        self = set(
+            localizableService: CustomLocalizableValueService(
+                with: localizationsDictionary,
+                defaultValue: defaultValue
+            )
+        )
     }
 
 }


### PR DESCRIPTION
Изменил тип словаря с `[Locale: String]` на `[String: String]`, теперь ключ `String` описывает первую часть Locale identifier(то есть если локаль "en_US", то ключ будет "en"). 

Так как варианты перевод хранятся в словаре, мы не сможем брать первый элемент словаря, так как не знаем что именно там лежит. Поэтому добавил еще и `defaultValue` - на тот случай, если будет локаль, для которой нет перевода