### PR TITLE
Update for Xcode 11

### DIFF
--- a/Autolocalizable/Classes/Localization/LocalizableStringItem.swift
+++ b/Autolocalizable/Classes/Localization/LocalizableStringItem.swift
@@ -37,7 +37,7 @@ public struct LocalizableStringItem {
         self.args = args
     }
 
-    public init(_ table: String, _ key: String, _ args: CVarArg...) {
+    public init(table: String, _ key: String, _ args: CVarArg...) {
         self.table = table
         self.key = key
         self.args = args

--- a/Autolocalizable/Classes/Localization/LocalizableStringItem.swift
+++ b/Autolocalizable/Classes/Localization/LocalizableStringItem.swift
@@ -9,8 +9,8 @@ import Foundation
 
 public struct LocalizableStringItem {
 
-    private enum Constants {
-        static let table = "Localizable"
+    public enum Constants {
+        public static let table = "Localizable"
     }
 
     // MARK: - Properties
@@ -31,13 +31,7 @@ public struct LocalizableStringItem {
 
     // MARK: - Initializing
 
-    public init(_ key: String = "", _ args: CVarArg...) {
-        self.table = Constants.table
-        self.key = key
-        self.args = args
-    }
-
-    public init(table: String, _ key: String, _ args: CVarArg...) {
+    public init(table: String = Constants.table, _ key: String = "", _ args: CVarArg...) {
         self.table = table
         self.key = key
         self.args = args

--- a/swiftgen-templates/strings/structured-swift4-dunamic.stencil
+++ b/swiftgen-templates/strings/structured-swift4-dunamic.stencil
@@ -32,10 +32,10 @@ import Foundation
   {% endif %}
   {% if string.types %}
   {{accessModifier}} static func {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> LocalizableStringItem {
-    return LocalizableStringItem("{{table}}", "{{string.key}}", {% call argumentsBlock string.types %})
+    return LocalizableStringItem(table: "{{table}}", "{{string.key}}", {% call argumentsBlock string.types %})
   }
   {% else %}
-    {{accessModifier}} static var {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: LocalizableStringItem { return LocalizableStringItem("{{table}}", "{{string.key}}") }
+    {{accessModifier}} static var {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: LocalizableStringItem { return LocalizableStringItem(table: "{{table}}", "{{string.key}}") }
   {% endif %}
   {% endfor %}
   {% for child in item.children %}


### PR DESCRIPTION
Следующая ситуация с инициализаторами в Xcode 11, по всей видимости будет рассматриваться как неоднозначная:
```swift
public init(_ key: String = "", _ args: CVarArg...) {
    self.table = Constants.table
    self.key = key
    self.args = args
}

public init(_ table: String, _ key: String, _ args: CVarArg...) {
    self.table = table
    self.key = key
    self.args = args
}
```
При `LocalizableStringItem("Value", "Key")` будет ошибка:
```
Ambiguous use of 'init'
```

Предлагаю поправить следующим образом:
```swift
public init(table: String = Constants.table, _ key: String = "", _ args: CVarArg...) {
    self.table = table
    self.key = key
    self.args = args
}
```

Это путь наименьшего сопротивления 🙃 В проекте кроме structured-swift4-dunamic.stencil скрипта ничего менять не придется.